### PR TITLE
Fix compilation error

### DIFF
--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -52,7 +52,7 @@ impl TryFrom<File> for Downloadable {
                 "mods"
             })
             .join(file.file_name),
-            size: Some(file.file_length),
+            size: Some(file.file_length as u64),
         })
     }
 }


### PR DESCRIPTION
Fix compilation error during `cargo install ferium`