### PR TITLE
Ability to get all major mc versions

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -2,17 +2,22 @@ use crate::HOME;
 use ferinth::Ferinth;
 use std::path::PathBuf;
 
-/// Get all Minecraft versions labeled as "Major"
-pub async fn get_major_mc_versions() -> Result<Vec<String>, ferinth::Error> {
+/// Get all Minecraft versions labeled as "Major".
+pub async fn get_all_major_mc_versions() -> Result<Vec<String>, ferinth::Error> {
     let all_versions = Ferinth::default().list_game_versions().await?;
 
     let string_versions: Vec<String> = all_versions
-        .iter()
+        .into_iter()
         .filter(|x| x.major)
-        .map(|x| x.version.clone())
+        .map(|x| x.version)
         .collect();
 
     Ok(string_versions)
+}
+
+// Get `count` number of the most recent Minecraft versions.
+pub async fn get_major_mc_versions(count: usize) -> Result<Vec<String>, ferinth::Error> {
+    Ok(get_all_major_mc_versions().await?.into_iter().take(count).collect::<Vec<String>>())
 }
 
 /// Get the default Minecraft instance directory based on the current OS.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -2,7 +2,7 @@ use crate::HOME;
 use ferinth::Ferinth;
 use std::path::PathBuf;
 
-/// Get a maximum of `count` number of the latest major versions of Minecraft
+/// Get all Minecraft versions labeled as "Major"
 pub async fn get_major_mc_versions() -> Result<Vec<String>, ferinth::Error> {
     let all_versions = Ferinth::default().list_game_versions().await?;
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -3,21 +3,16 @@ use ferinth::Ferinth;
 use std::path::PathBuf;
 
 /// Get a maximum of `count` number of the latest major versions of Minecraft
-pub async fn get_major_mc_versions(mut count: usize) -> Result<Vec<String>, ferinth::Error> {
-    let versions = Ferinth::default().list_game_versions().await?;
-    let mut major_versions = Vec::new();
+pub async fn get_major_mc_versions() -> Result<Vec<String>, ferinth::Error> {
+    let all_versions = Ferinth::default().list_game_versions().await?;
 
-    for version in versions {
-        if count == 0 {
-            break;
-        }
-        if version.major {
-            major_versions.push(version.version);
-            count -= 1;
-        }
-    }
+    let string_versions: Vec<String> = all_versions
+        .iter()
+        .filter(|x| x.major)
+        .map(|x| x.version.clone())
+        .collect();
 
-    Ok(major_versions)
+    Ok(string_versions)
 }
 
 /// Get the default Minecraft instance directory based on the current OS.


### PR DESCRIPTION
This is nessessary so that ferium can have the ability get chose any mc versions without having hard-coded values in `get_major_mc_versions()`. (As mentioned in https://github.com/gorilla-devs/ferium/pull/260#issuecomment-1381896657)